### PR TITLE
fix: Decode special characters using the DOM

### DIFF
--- a/client/components/game/choose-card-combination.vue
+++ b/client/components/game/choose-card-combination.vue
@@ -5,9 +5,8 @@
         color="black"
         class="sm:h-96 w-full sm:w-64 mb-4"
         :disabled="true"
-      >
-        {{ blackCard.text }}
-      </app-playcard>
+        :text="blackCard.text"
+      />
       <app-button
         class="w-full"
         :disabled="canSelectCard"
@@ -36,9 +35,8 @@
             class="h-full lg:h-96 w-full lg:w-64"
             :disabled="!canSelectCard"
             :step="index + 1"
-          >
-            {{ card.text }}
-          </app-playcard>
+            :text="card.text"
+          />
         </div>
 
         <div

--- a/client/components/game/choose-cards.vue
+++ b/client/components/game/choose-cards.vue
@@ -38,10 +38,9 @@
           class="h-full lg:h-96 w-full lg:w-64"
           :step="cardNumber(card)"
           :disabled="!(canSelectCard || cardNumber(card) > 0)"
+          :text="card.text"
           @toggle="toggleCard(card)"
-        >
-          {{ card.text }}
-        </app-playcard>
+        />
       </div>
     </template>
   </app-game-view>

--- a/client/components/game/playcard.vue
+++ b/client/components/game/playcard.vue
@@ -6,7 +6,9 @@
   >
     <app-card-content class="h-full">
       <p>
-        <slot></slot>
+        <slot>
+          {{ encodedText }}
+        </slot>
       </p>
     </app-card-content>
 
@@ -36,6 +38,7 @@ import { Component, Vue, Prop, Emit } from 'vue-property-decorator'
 })
 export default class AppPlaycard extends Vue {
   @Prop({ default: 'white', type: String }) color!: 'black' | 'white'
+  @Prop({ default: '', type: String, required: false }) text?: string
   @Prop({ default: null, type: [String, Number] }) step!: number
   @Prop({ default: false, type: [Boolean] }) disabled!: boolean
 
@@ -53,6 +56,12 @@ export default class AppPlaycard extends Vue {
       'bg-white text-black': this.color === 'black',
       'bg-black text-white': this.color === 'white',
     }
+  }
+
+  get encodedText() {
+    const element = document.createElement('div')
+    element.innerHTML = this.text
+    return element.textContent
   }
 
   @Emit('toggle')

--- a/client/components/game/show-best-combination.vue
+++ b/client/components/game/show-best-combination.vue
@@ -5,9 +5,8 @@
         color="black"
         class="sm:h-96 w-full sm:w-64 mb-4"
         :disabled="true"
-      >
-        {{ blackCard.text }}
-      </app-playcard>
+        :text="blackCard.text"
+      />
       <app-button class="w-full" @click.native="nextRound">
         Next round
       </app-button>
@@ -23,9 +22,8 @@
           class="lg:h-96 w-full lg:w-64"
           :step="index + 1"
           :disabled="true"
-        >
-          {{ card.text }}
-        </app-playcard>
+          :text="card.text"
+        />
       </div>
     </template>
   </app-game-view>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Add an extra property to playcards. The value assigned to this property is than decoded and shown to the user.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Issue #26.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
When I get cards that contain specials characters like © they are rendered as encoded HTML entities. So © is rendered as \&copy;.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This is tested by hand.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.