### PR TITLE
fix: Keep track of current round in session

### DIFF
--- a/client/components/game/choose-cards.vue
+++ b/client/components/game/choose-cards.vue
@@ -71,8 +71,11 @@ import { CardView } from '~/models/Card'
       this.isPreviousCzar = !oldValue
     },
 
-    blackCard(_, { numAnswers }: CardView) {
-      if (numAnswers && !this.isPreviousCzar) {
+    blackCard(
+      { id: newCard }: CardView,
+      { id: oldCard, numAnswers }: CardView,
+    ) {
+      if (newCard !== oldCard && numAnswers && !this.isPreviousCzar) {
         this.fetchNewCards(numAnswers)
       }
     },
@@ -131,7 +134,11 @@ export default class AppChooseCards extends Vue {
     const cardsWithoutOld = this.cards.filter(
       card => !this.selectedCards.includes(card),
     )
-    this.cards = cardsWithoutOld.concat(newCards)
+
+    // Force the use of exactly 10 cards.
+    if (cardsWithoutOld.length !== 10) {
+      this.cards = cardsWithoutOld.concat(newCards)
+    }
 
     // Reset the selected cards with an empty array.
     return []

--- a/client/pages/game/_game/play.vue
+++ b/client/pages/game/_game/play.vue
@@ -102,9 +102,6 @@ export default class PlayGame extends Vue {
   /** @var game - The game that is currently being played. */
   game!: GameView
 
-  /** @var round - The number of the current round. */
-  round: number = 0
-
   /** @var session - The session the user is currently in. */
   session: any = {}
 
@@ -139,6 +136,11 @@ export default class PlayGame extends Vue {
   /** Determine if the current user is the card czar */
   get isCzar(): boolean {
     return this.session.currentCzarId === this.$auth.user.id
+  }
+
+  /** @var round - The number of the current round. */
+  get round(): number {
+    return this.session.currentRound || 0
   }
 
   beforeMount() {
@@ -182,9 +184,9 @@ export default class PlayGame extends Vue {
   }
 
   onSessionJoin(session) {
-    this.updatePlayedCards(session)
-    this.session = session
+    this.session = { ...this.session, ...session }
     this.blackCards = [...this.blackCards, session.currentCard]
+    this.updatePlayedCards(session)
   }
 
   /**
@@ -204,7 +206,6 @@ export default class PlayGame extends Vue {
   }
 
   onSessionNextRound(session) {
-    this.round++
     this.onSessionJoin(session)
     this.state = 'choose-cards'
   }
@@ -232,7 +233,7 @@ export default class PlayGame extends Vue {
     this.state = 'show-best-combination'
   }
 
-  updatePlayedCards({ playerInSession, currentCzarId }) {
+  updatePlayedCards({ playerInSession }) {
     const cardsByActivePlayers = playerInSession
       // Get the cards played by the user.
       .map(({ playerCards }) => {
@@ -240,10 +241,7 @@ export default class PlayGame extends Vue {
         return (round || {}).cards
       })
       // Filter items that are falsy.
-      .filter(
-        playerSession =>
-          !!playerSession && playerSession.playerId !== currentCzarId,
-      )
+      .filter(card => !!card)
 
     this.playedCards[this.round] = cardsByActivePlayers
     this.playedCards = [...this.playedCards]

--- a/server/src/sessions/service/sessions.service.ts
+++ b/server/src/sessions/service/sessions.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@nestjs/common'
 import { InjectRepository } from '@nestjs/typeorm'
 import { Session } from '../session.entity'
 import { Repository } from 'typeorm'
-import { Socket, Server } from 'socket.io'
+import { Socket } from 'socket.io'
 import { from, Observable } from 'rxjs'
 import { map, tap } from 'rxjs/operators'
 import { WsResponse } from '@nestjs/websockets'
@@ -138,6 +138,7 @@ export class SessionsService {
    * @param session - The current session of the game.
    */
   async setupSessionForNextRound(session: Session): Promise<Session> {
+    session.currentRound++
     await this.setupSession(session)
     await this.chooseCzar(session)
     return this.getSession(session.id)
@@ -229,10 +230,12 @@ export class SessionsService {
     id,
     game,
     room,
+    currentRound = 0,
   }: {
     id?: string
     game: GameJoinDto
     room: string
+    currentRound?: number
   }) {
     const [currentCard] = await this.cardsService.findAll({
       skip: 0,
@@ -245,6 +248,7 @@ export class SessionsService {
       game,
       room,
       currentCard,
+      currentRound,
     })
   }
 

--- a/server/src/sessions/session.entity.ts
+++ b/server/src/sessions/session.entity.ts
@@ -20,6 +20,9 @@ export class Session {
   @Column()
   room!: string
 
+  @Column({ type: 'int', nullable: true })
+  currentRound: number = 0
+
   @OneToOne(() => Game)
   @JoinColumn()
   game!: Game


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Keep track of the current round and use that number as reference for new players. Also force the use of exactly 10 play cards.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes: #25

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
The player that is new or reloaded the page doesn't get to see all the cards played by everyone else.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
By hand 👌

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
