### PR TITLE
fix: Reset czar on exit

### DIFF
--- a/server/src/cards/cards.module.ts
+++ b/server/src/cards/cards.module.ts
@@ -1,13 +1,13 @@
-import { Module } from '@nestjs/common';
-import { CardsService } from './service/cards.service';
-import { CardsController } from './controller/cards.controller';
-import { Card } from './card.entity';
-import { TypeOrmModule } from '@nestjs/typeorm';
+import { Module } from '@nestjs/common'
+import { CardsService } from './service/cards.service'
+import { CardsController } from './controller/cards.controller'
+import { Card } from './card.entity'
+import { TypeOrmModule } from '@nestjs/typeorm'
 
 @Module({
   imports: [TypeOrmModule.forFeature([Card])],
   providers: [CardsService],
   controllers: [CardsController],
-  exports: [CardsService]
+  exports: [CardsService],
 })
-export class CardsModule { }
+export class CardsModule {}

--- a/server/src/games/games.module.ts
+++ b/server/src/games/games.module.ts
@@ -1,12 +1,13 @@
-import { Module } from '@nestjs/common';
-import { TypeOrmModule } from '@nestjs/typeorm';
-import { Game } from './game.entity';
-import { GamesService } from './service/games.service';
-import { GamesController } from './controller/games.controller';
+import { Module } from '@nestjs/common'
+import { TypeOrmModule } from '@nestjs/typeorm'
+import { Game } from './game.entity'
+import { GamesService } from './service/games.service'
+import { GamesController } from './controller/games.controller'
 
 @Module({
   imports: [TypeOrmModule.forFeature([Game])],
   providers: [GamesService],
   controllers: [GamesController],
+  exports: [GamesService],
 })
 export class GamesModule {}

--- a/server/src/games/service/games.service.ts
+++ b/server/src/games/service/games.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common'
 import { InjectRepository } from '@nestjs/typeorm'
-import { Repository, InsertResult, FindOneOptions } from 'typeorm'
+import { Repository, FindOneOptions, FindConditions } from 'typeorm'
 import { Game } from '../game.entity'
 import { GameCreateDto } from '../game.dto'
 
@@ -13,6 +13,10 @@ export class GamesService {
 
   create(game: GameCreateDto): Promise<Game> {
     return this.gameRepository.save(game)
+  }
+
+  remove(options: FindConditions<Game>) {
+    return this.gameRepository.delete(options)
   }
 
   findAll(): Promise<Game[]> {

--- a/server/src/sessions/service/sessions.service.ts
+++ b/server/src/sessions/service/sessions.service.ts
@@ -168,12 +168,12 @@ export class SessionsService {
    * Choose a (new) czar for this session.
    * @param session - The session to choose the Czar for.
    */
-  async chooseCzar(session: Session): Promise<void> {
+  async chooseCzar(session: Session, isExit?: boolean): Promise<void> {
     const playersInSession = await this.playerInSessionsService.find({
       where: { session },
     })
 
-    const nextCzarId = this.getNextCzarId(session, playersInSession)
+    const nextCzarId = this.getNextCzarId(session, playersInSession, isExit)
 
     if (nextCzarId !== session.currentCzarId) {
       this.sessionRepository.update(session.id, {
@@ -185,8 +185,9 @@ export class SessionsService {
   private getNextCzarId(
     { currentCzarId }: Session,
     playersInSession: PlayerInSession[],
+    isExit = false,
   ) {
-    if (playersInSession.length === 0) {
+    if (playersInSession.length === 1 && isExit) {
       return null
     }
 
@@ -297,7 +298,7 @@ export class SessionsService {
     const session = await this.sessionRepository.findOne({ where: { room } })
 
     if (session.currentCzarId === user.id) {
-      await this.chooseCzar(session)
+      await this.chooseCzar(session, true)
     }
 
     await this.playerInSessionsService.remove({

--- a/server/src/sessions/service/sessions.service.ts
+++ b/server/src/sessions/service/sessions.service.ts
@@ -12,6 +12,7 @@ import { User } from '../../users/user.entity'
 import { PlayerSessionService } from '../../player-session/service/player-session.service'
 import { PlayerInSession } from '../../player-session/player-session.entity'
 import { SessionData } from '../session.types'
+import { GamesService } from '../../games/service/games.service'
 
 @Injectable()
 export class SessionsService {
@@ -19,6 +20,7 @@ export class SessionsService {
     @InjectRepository(Session)
     private readonly sessionRepository: Repository<Session>,
     private readonly cardsService: CardsService,
+    private readonly gamesService: GamesService,
     private readonly playerInSessionsService: PlayerSessionService,
   ) {}
 
@@ -183,6 +185,10 @@ export class SessionsService {
     { currentCzarId }: Session,
     playersInSession: PlayerInSession[],
   ) {
+    if (playersInSession.length === 0) {
+      return null
+    }
+
     let currentCzarIndex: number = -1
 
     if (currentCzarId) {

--- a/server/src/sessions/session.entity.ts
+++ b/server/src/sessions/session.entity.ts
@@ -20,6 +20,9 @@ export class Session {
   @Column()
   room!: string
 
+  @Column()
+  gameId: string
+
   @OneToOne(() => Game)
   @JoinColumn()
   game!: Game

--- a/server/src/sessions/sessions.module.ts
+++ b/server/src/sessions/sessions.module.ts
@@ -7,10 +7,12 @@ import { CardsModule } from '../cards/cards.module'
 import { AuthModule } from '../auth/auth.module'
 import { PlayerSessionModule } from '../player-session/player-session.module'
 import { UsersModule } from '../users/users.module'
+import { GamesModule } from '../games/games.module'
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([Session]),
+    GamesModule,
     CardsModule,
     AuthModule,
     UsersModule,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Reset the `currentCzarId` of the session to `null` when the player that exits is the last in the session.

## Description

<!--- Describe your changes in detail -->
Remove the current Czar in the session to select a new one when a new player joins. This only happens when the player that exists is the last in the session.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Resolves #31 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
When the czar of a session is not reset when the last player exits the next player that joins the session cannot play the game until 

The new Czar is not chosen when a player joins an empty game. This is caused by not resetting the czar when the last player exists the session.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Join a game in two browser sessions.
2. Exit the game in both browser sessions.
3. Join the game with the browser session that exited first.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
