### PR TITLE
fix: use regex to lengthen all blank spaces

### DIFF
--- a/client/components/game/playcard.vue
+++ b/client/components/game/playcard.vue
@@ -61,7 +61,7 @@ export default class AppPlaycard extends Vue {
   get encodedText() {
     const element = document.createElement('div')
     element.innerHTML =
-      this.color === 'white' ? this.text : this.text.replace('_', '__________')
+      this.color === 'white' ? this.text : this.text.replace(/_/g, '__________')
     return element.textContent
   }
 


### PR DESCRIPTION
## Description

This PR fixes an issue where only the first blank space was lengthened.

## Related Issue

Second and third blank spaces are too small #60

## Motivation and Context

The black cards looked weird when they had multiple blank spaces.

## How Has This Been Tested?

Manually checking a black card with multiple blank spaces.

## Screenshots (if appropriate):

Before:
![image](https://user-images.githubusercontent.com/47106797/66642265-ae5bc500-ec1c-11e9-9e6c-34f4ce5e213e.png)

After:
![image](https://user-images.githubusercontent.com/47106797/66642171-76ed1880-ec1c-11e9-8805-73f7a24965c5.png)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
